### PR TITLE
Add Python trading script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,24 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+## Python trading example
+
+A simple trading script is available in `auto_trader.py`. It uses `yfinance` to
+retrieve market data and `alpaca_trade_api` to place orders. Set the following
+environment variables before running:
+
+```
+export ALPACA_API_KEY=<your key>
+export ALPACA_SECRET_KEY=<your secret>
+export TRADE_SYMBOL=AAPL  # or any stock symbol
+```
+
+Execute the script with:
+
+```
+python auto_trader.py
+```
+
+The example implements a basic moving average strategy and submits market orders
+through the Alpaca API.

--- a/auto_trader.py
+++ b/auto_trader.py
@@ -1,0 +1,55 @@
+import os
+import time
+
+import yfinance as yf
+from alpaca_trade_api.rest import REST
+
+
+class MovingAverageTrader:
+    """Simple moving average trading example using Alpaca API."""
+
+    def __init__(self, symbol: str, window: int = 20):
+        self.symbol = symbol
+        self.window = window
+        self.api = REST(
+            os.getenv("ALPACA_API_KEY"),
+            os.getenv("ALPACA_SECRET_KEY"),
+            os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets"),
+        )
+
+    def latest_price(self) -> float:
+        data = yf.Ticker(self.symbol).history(period="1d", interval="1m")
+        return float(data["Close"].iloc[-1])
+
+    def moving_average(self) -> float:
+        data = yf.Ticker(self.symbol).history(period=f"{self.window}m", interval="1m")
+        return float(data["Close"].rolling(self.window).mean().iloc[-1])
+
+    def trade(self):
+        price = self.latest_price()
+        ma = self.moving_average()
+        side = "buy" if price > ma else "sell"
+        self.api.submit_order(
+            symbol=self.symbol,
+            qty=1,
+            side=side,
+            type="market",
+            time_in_force="day",
+        )
+        print(f"{side.capitalize()} {self.symbol} at {price:.2f}")
+
+
+def main():
+    symbol = os.getenv("TRADE_SYMBOL", "AAPL")
+    trader = MovingAverageTrader(symbol)
+    while True:
+        try:
+            trader.trade()
+            time.sleep(60)
+        except Exception as exc:
+            print(f"Error during trade: {exc}")
+            time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `auto_trader.py` demonstrating a moving-average trading bot using Alpaca API
- document how to run the Python example in the README

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879cbb2ec1c832497047ab107834895